### PR TITLE
DEV-139 - 0122670 - hook load_plugin_text_domain to init

### DIFF
--- a/vendor/kminh/bwp-framework/src/class-bwp-framework-v3.php
+++ b/vendor/kminh/bwp-framework/src/class-bwp-framework-v3.php
@@ -255,7 +255,9 @@ abstract class BWP_Framework_V3
 		$this->init_actions();
 
 		// Load locale
-		$this->bridge->load_plugin_textdomain($this->domain, false, $this->plugin_folder . '/languages');
+		add_action('init', function () {
+            $this->bridge->load_plugin_textdomain($this->domain, false, $this->plugin_folder . '/languages');
+        });
 	}
 
 	protected function add_option_key($key, $option, $title)


### PR DESCRIPTION
https://myersmediagroupllc.atlassian.net/browse/DEV-139

I have a couple of questions:
1) Do I need to do something else to make CMS use the version of this branch after the PR? 
2) Even if this removes the warning, how can I test the plugin still works after the change?